### PR TITLE
update restart button functionality & resolve issue

### DIFF
--- a/index.html
+++ b/index.html
@@ -73,7 +73,7 @@
           </div>
         </section>
         <div class="game-reset-btn">
-          <button id="reset-btn">RESTART</button>
+          <button id="reset-btn" class="reset-button-disabled" onclick="resetGame()" disabled>RESTART</button>
         </div>
       </section>
     </section>

--- a/main.js
+++ b/main.js
@@ -10,8 +10,8 @@ let computerScoreCount = 0;
 
 // function to reset the game to score 0:0
 function resetGame(){
-    computerScore.innerHTML = `0`;
-    playerScore.innerHTML = `0`;
+    computerScore.textContent = "0";
+    playerScore.textContent = "0";
     gameReset.classList.add("reset-button-disabled");
 }
 

--- a/main.js
+++ b/main.js
@@ -2,14 +2,27 @@ const gameplayInfoText = document.getElementById("gameplay-info-text")
 const playerEmoji = document.getElementById("player-emoji");
 const computerEmoji = document.getElementById("computer-emoji");
 const choices = ["rock", "paper", "scissors"];
-const gameReset = document.getElementById("reset-btn");
+var gameReset = document.getElementById("reset-btn");
 let computerScore = document.getElementById("computer-score");
 let playerScore = document.getElementById("player-score");
 let playerScoreCount = 0;
 let computerScoreCount = 0;
 
+// function to reset the game to score 0:0
+function resetGame(){
+    computerScore.innerHTML = `0`;
+    playerScore.innerHTML = `0`;
+    gameReset.classList.add("reset-button-disabled");
+}
+
+// function that occurs when either of the game action icons are pressed
 function playGame(playerChoice){
     let computerChoice = choices[Math.trunc(Math.random() * 3)];
+    gameReset.classList.remove("reset-button-disabled");
+    gameReset.classList.add("reset-button");
+    gameReset.disabled = false; // enables restart to allow the user to restart the game
+    
+
     if (playerChoice == "rock"){
         playerEmoji.textContent = "✊";
     } else if (playerChoice == "paper"){
@@ -59,11 +72,5 @@ function playGame(playerChoice){
             computerScoreCount++;
             computerScore.innerHTML = `${computerScoreCount}`;
         }
-
     }
 }
-
-gameReset.addEventListener("click", () => {
-    playerScore.innerHTML = `0`;
-    computerScore.innerHTML = `0`;
-})

--- a/style.css
+++ b/style.css
@@ -10,6 +10,7 @@
   --color-3: #c7ffd8;
   --color-4: #f6f6f6;
   --color-6: #97ebe5;
+  --color-7: #a80606;
   --game-font: "Press Start 2P", system-ui;
 }
 
@@ -125,7 +126,7 @@ html {
   background-color: var(--color-2);
 }
 
-#reset-btn{
+.reset-button{
   text-align: center;
   padding: .8rem .8rem;
   border: none;
@@ -137,10 +138,22 @@ html {
   transition-duration: .5s;
 }
 
-#reset-btn:hover{
+.reset-button:hover{
   scale: 1.1;
   background-color: var(--color-4);
   color: var(--color-1);
+}
+
+.reset-button-disabled{
+  text-align: center;
+  padding: .8rem .8rem;
+  border: none;
+  border-radius: 1rem;
+  font-family: "Press Start 2P", system-ui;
+  color: var(--color-7);
+  background-color: var(--color-3);
+  cursor: pointer;
+  text-decoration: line-through;
 }
 /* end of restart button styling */
 

--- a/style.css
+++ b/style.css
@@ -155,6 +155,12 @@ html {
   cursor: pointer;
   text-decoration: line-through;
 }
+
+.reset-button-disabled:hover{
+  scale: 1.05;
+  background-color: var(--color-7);
+  color: var(--color-4);
+}
 /* end of restart button styling */
 
 /* start of media queries */


### PR DESCRIPTION
- add 'restart-button-disabled' as the default class for the restart button
- set restart button to disabled by default to ensure that the player can only restart when the game has started.
- add onclick function 'resetGame()' to the button
- modify gameReset data type to var, for leter alterations
- add resetGame() function to main.js, that resets scores to '0'
  - add classList functions to the playGame() function:
  - 'add' for the 'reset button' class
- 'remove' for the 'reset-buetton-disabled' class
- modify gameReset.disabled to 'false' in the playGame() function, allowing user to reset
- add color variable to root variables in style.css
- modify the styling of the reset button to use class 'reset-button' and 'reset-button-disabled'
- replace 'innerHTML' with 'textContent' for the score reset function
- add hover effect styling to 'reset-buttno-disabled- class.

## Summary by Sourcery

Enable the restart button only after the game begins by disabling it by default and wiring it to reset game state.

New Features:
- Add resetGame() function to clear scores and re-disable the restart button
- Bind resetGame() to the restart button via an onclick handler

Bug Fixes:
- Prevent users from restarting before the game starts by disabling the restart button by default

Enhancements:
- Migrate reset button styling from ID to class-based .reset-button and .reset-button-disabled with hover effects using a new root color variable
- Switch score reset updates from innerHTML to textContent and toggle button state via classList
- Change gameReset element declaration to var and enable toggling its disabled property when the game starts